### PR TITLE
[feature] update to 'minidom:0.13.0'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "minidom_writer"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Kisio Digital <team.coretools@kisio.com>"]
 license = "MIT"
 description = "Helper to write into a std::io::Write a minidom::Element"
@@ -12,8 +12,7 @@ readme = "README.md"
 keywords = ["minidom", "extension", "writer"]
 
 [dependencies]
-minidom = "0.12"
-quick-xml = "0.17"
+minidom = "0.13"
 thiserror = "1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -6,5 +6,20 @@
 [Latest Version]: https://img.shields.io/crates/v/minidom_writer.svg    
 [crates.io]: https://crates.io/crates/minidom_writer                    
 
+⚠ This project is archived and last `minidom` version supported is `0.13.0` ⚠
+`minidom` now provides substantial functionality to write an XML file, see the following API:
+
+- [`Element::to_writer()`][to_writer]
+- [`Element::to_writer_decl()`][to_writer_decl]
+- [`Element::write_to()`][write_to]
+- [`Element::write_to_decl()`][write_to_decl]
+- [`Element::write_to_inner()`][write_to_inner]
+
+[to_writer]: https://docs.rs/minidom/0.13.0/minidom/element/struct.Element.html#method.to_writer
+[to_writer_decl]: https://docs.rs/minidom/0.13.0/minidom/element/struct.Element.html#method.to_writer_decl
+[write_to]: https://docs.rs/minidom/0.13.0/minidom/element/struct.Element.html#method.write_to
+[write_to_decl]: https://docs.rs/minidom/0.13.0/minidom/element/struct.Element.html#method.write_to_decl
+[write_to_inner]: https://docs.rs/minidom/0.13.0/minidom/element/struct.Element.html#method.write_to_inner
+
 # minidom_writer
 Helper to write 'minidom::Element' into an XML. See [documentation](https://docs.rs/minidom_writer).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@
 //! use minidom_writer::ElementWriter;
 //! use std::io::Cursor;
 //!
-//! let subtag = Element::builder("ns:subtag")
+//! let subtag = Element::builder("subtag", "ns")
 //!     .attr("id", "my_subtag")
 //!     .append(Node::Text(String::from("Some text")))
 //!     .build();
-//! let tag = Element::builder("tag")
+//! let tag = Element::builder("tag", "")
 //!     .attr("id", "my_tag")
 //!     .append(subtag)
 //!     .build();
@@ -46,5 +46,5 @@ pub enum Error {
     /// [`quick-xml`]: ../quick_xml/index.html
     /// [`quick-xml::Error`]: ../quick_xml/enum.Error.html
     #[error("Error writing an XML tag with quick-xml")]
-    WriteEventError(#[from] quick_xml::Error),
+    WriteEventError(#[from] minidom::quick_xml::Error),
 }


### PR DESCRIPTION
`minidom_writer` will not be needed anymore, so I propose to release the last version of this crate, updated to `minidom:0.13.0`, in order to make the new README appears on crates.io.